### PR TITLE
FLEcli

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 
 - [CloudLogOffline](https://github.com/myzinsky/cloudLogOffline) - App frontend for wavelog and cloudlog.
 - [wavelog](https://www.wavelog.org/) - Web based amateur radio logging software.
-- [FLEcli](https://github.com/on4kjm/FLEcli) - Command line utility for processing log files in the Fast Log Entrly (FLE) format.
+- [FLEcli](https://github.com/on4kjm/FLEcli) - Command line utility for processing log files in the Fast Log Entry (FLE) format.
 - [FLE for VSCode](https://github.com/xssfox/flecode) - Syntax highliting of the Fast Log Entry format for VSCode.
 - [FLE for Vim](https://git.sdf.org/odie/vim-fle-syntax) - Syntax highliting of the Fast Log Entry format for Vim.
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@
 - [wavelog](https://www.wavelog.org/) - Web based amateur radio logging software.
 - [FLEcli](https://github.com/on4kjm/FLEcli) - Command line utility for processing log files in the Fast Log Entrly (FLE) format.
 - [FLE for VSCode](https://github.com/xssfox/flecode) - Syntax highliting of the Fast Log Entry format for VSCode.
+- [FLE for Vim](https://git.sdf.org/odie/vim-fle-syntax) - Syntax highliting of the Fast Log Entry format for Vim.
 
 ### Modes
 

--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@
 - [CloudLogOffline](https://github.com/myzinsky/cloudLogOffline) - App frontend for wavelog and cloudlog.
 - [wavelog](https://www.wavelog.org/) - Web based amateur radio logging software.
 - [FLEcli](https://github.com/on4kjm/FLEcli) - Command line utility for processing log files in the Fast Log Entry (FLE) format.
-- [FLE for VSCode](https://github.com/xssfox/flecode) - Syntax highliting of the Fast Log Entry format for VSCode.
-- [FLE for Vim](https://git.sdf.org/odie/vim-fle-syntax) - Syntax highliting of the Fast Log Entry format for Vim.
+- [FLE for VSCode](https://github.com/xssfox/flecode) - Syntax highlighting of the Fast Log Entry format for VSCode.
+- [FLE for Vim](https://git.sdf.org/odie/vim-fle-syntax) - Syntax highlighting of the Fast Log Entry format for Vim.
 
 ### Modes
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@
 - [CloudLogOffline](https://github.com/myzinsky/cloudLogOffline) - App frontend for wavelog and cloudlog.
 - [wavelog](https://www.wavelog.org/) - Web based amateur radio logging software.
 - [FLEcli](https://github.com/on4kjm/FLEcli) - Command line utility for processing log files in the Fast Log Entrly (FLE) format.
+- [FLE for VSCode](https://github.com/xssfox/flecode) - Syntax highliting of the Fast Log Entry format for VSCode.
 
 ### Modes
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@
 
 - [CloudLogOffline](https://github.com/myzinsky/cloudLogOffline) - App frontend for wavelog and cloudlog.
 - [wavelog](https://www.wavelog.org/) - Web based amateur radio logging software.
+- [FLEcli](https://github.com/on4kjm/FLEcli) - Command line utility for processing log files in the Fast Log Entrly (FLE) format.
 
 ### Modes
 


### PR DESCRIPTION
Fast Log Entry is an plain text log format. I find it especially valuable to bulk process a hand written log (from SOTA, POTA or other outdoor activities). The FLEcli allows to convert this into other formats (ADIF, SOTA csv), allowing the logs to be imported elsewhere.